### PR TITLE
Rework store link logic to account for customized permalinks/labels #10

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -16,7 +16,7 @@ if( ! defined( 'ABSPATH' ) ) exit;
  * @since       1.0.0
  */
 function eddcs_continue_shopping_link() {
-	if ( ! edd_get_option( 'edd_continue_shopping' ) ) {
+	if ( edd_get_option( 'edd_continue_shopping' ) ) {
 		return;
 	}
 
@@ -48,4 +48,3 @@ function eddcs_continue_shopping_link() {
 	<?php
 }
 add_action( 'edd_cart_footer_buttons', 'eddcs_continue_shopping_link' );
-

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -17,14 +17,31 @@ if( !defined( 'ABSPATH' ) ) exit;
  */
 function eddcs_continue_shopping_link() {
 	if ( class_exists( 'Easy_Digital_Downloads' ) && !edd_get_option( 'edd_continue_shopping' ) ) {
-		$store_link        = edd_get_option( 'edd_continue_shopping_page' );
+		$store_page        = edd_get_option( 'edd_continue_shopping_page' );
 		$cs_text           = edd_get_option( 'edd_continue_shopping_text' );
 		$cs_link_type      = edd_get_option( 'edd_continue_shopping_link_type' );
 		$color             = edd_get_option( 'checkout_color', 'blue' );
 		$color             = ( $color == 'inherit' ) ? '' : $color;
+
+		$store_link = false;
+		if ( ! empty( $store_page ) ) {
+			$store_link = get_permalink( $store_page );
+		}
+		if ( empty( $store_link ) ) {
+			$store_link = get_post_type_archive_link( 'download' );
+		}
+
+		/*
+		 * This could still be empty if no page is selected and archives have been disabled
+		 * for the `download` post type.
+		 */
+		if ( empty( $store_link ) ) {
+			return;
+		}
 		?>
-		<a href="<?php echo $store_link ? get_permalink( $store_link ) : home_url( '/' . lcfirst( edd_get_label_plural() ) ); ?>" class="edd-continue-shopping-button <?php echo 'text' == $cs_link_type ? '' : 'edd-submit button ' . $color; ?>" style="<?php echo 'text' == $cs_link_type ? 'font-size: inherit; font-weight: 400; margin-right: 4px;' : 'text-decoration: none;'; ?>"><?php if ( false === $cs_text ) { _e( 'Continue Shopping', 'edd-continue-shopping' ); } elseif ( !empty( $cs_text ) ) { echo $cs_text; } ?></a>
+		<a href="<?php echo esc_url( $store_link ); ?>" class="edd-continue-shopping-button <?php echo 'text' == $cs_link_type ? '' : 'edd-submit button ' . $color; ?>" style="<?php echo 'text' == $cs_link_type ? 'font-size: inherit; font-weight: 400; margin-right: 4px;' : 'text-decoration: none;'; ?>"><?php if ( false === $cs_text ) { _e( 'Continue Shopping', 'edd-continue-shopping' ); } elseif ( !empty( $cs_text ) ) { echo $cs_text; } ?></a>
 		<?php
 	}
 }
 add_action( 'edd_cart_footer_buttons', 'eddcs_continue_shopping_link' );
+

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -16,36 +16,36 @@ if( ! defined( 'ABSPATH' ) ) exit;
  * @since       1.0.0
  */
 function eddcs_continue_shopping_link() {
-	if ( class_exists( 'Easy_Digital_Downloads' ) && ! edd_get_option( 'edd_continue_shopping' ) ) {
-		$store_page        = edd_get_option( 'edd_continue_shopping_page' );
-		$cs_text           = edd_get_option( 'edd_continue_shopping_text' );
-		$cs_link_type      = edd_get_option( 'edd_continue_shopping_link_type' );
-		$color             = edd_get_option( 'checkout_color', 'blue' );
-		$color             = ( $color == 'inherit' ) ? '' : $color;
-
-		$store_link = false;
-		if ( ! empty( $store_page ) ) {
-			$store_link = get_permalink( $store_page );
-		}
-		if ( empty( $store_link ) ) {
-			$store_link = get_post_type_archive_link( 'download' );
-		}
-
-		/*
-		 * This could still be empty if no page is selected and archives have been disabled
-		 * for the `download` post type.
-		 */
-		if ( empty( $store_link ) ) {
-			return;
-		}
-
-		$link_text = ! empty( $cs_text ) ? $cs_text : __( 'Continue Shopping', 'edd-continue-shopping' );
-		?>
-		<a href="<?php echo esc_url( $store_link ); ?>" class="edd-continue-shopping-button <?php echo 'text' == $cs_link_type ? '' : 'edd-submit button ' . $color; ?>" style="<?php echo 'text' == $cs_link_type ? 'font-size: inherit; font-weight: 400; margin-right: 4px;' : 'text-decoration: none;'; ?>">
-			<?php echo esc_html( $link_text ); ?>
-		</a>
-		<?php
+	if ( ! edd_get_option( 'edd_continue_shopping' ) ) {
+		return;
 	}
+
+	$store_page        = edd_get_option( 'edd_continue_shopping_page' );
+	$cs_text           = edd_get_option( 'edd_continue_shopping_text', __( 'Continue Shopping', 'edd-continue-shopping' ) );
+	$cs_link_type      = edd_get_option( 'edd_continue_shopping_link_type' );
+	$color             = edd_get_option( 'checkout_color', 'blue' );
+	$color             = ( $color == 'inherit' ) ? '' : $color;
+
+	$store_link = false;
+	if ( ! empty( $store_page ) ) {
+		$store_link = get_permalink( $store_page );
+	}
+	if ( empty( $store_link ) ) {
+		$store_link = get_post_type_archive_link( 'download' );
+	}
+
+	/*
+	 * This could still be empty if no page is selected and archives have been disabled
+	 * for the `download` post type.
+	 */
+	if ( empty( $store_link ) ) {
+		return;
+	}
+	?>
+	<a href="<?php echo esc_url( $store_link ); ?>" class="edd-continue-shopping-button <?php echo 'text' == $cs_link_type ? '' : 'edd-submit button ' . $color; ?>" style="<?php echo 'text' == $cs_link_type ? 'font-size: inherit; font-weight: 400; margin-right: 4px;' : 'text-decoration: none;'; ?>">
+		<?php echo esc_html( $cs_text ); ?>
+	</a>
+	<?php
 }
 add_action( 'edd_cart_footer_buttons', 'eddcs_continue_shopping_link' );
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -7,7 +7,7 @@
  */
 
 // Exit if accessed directly
-if( !defined( 'ABSPATH' ) ) exit;
+if( ! defined( 'ABSPATH' ) ) exit;
 
 
 /**
@@ -16,7 +16,7 @@ if( !defined( 'ABSPATH' ) ) exit;
  * @since       1.0.0
  */
 function eddcs_continue_shopping_link() {
-	if ( class_exists( 'Easy_Digital_Downloads' ) && !edd_get_option( 'edd_continue_shopping' ) ) {
+	if ( class_exists( 'Easy_Digital_Downloads' ) && ! edd_get_option( 'edd_continue_shopping' ) ) {
 		$store_page        = edd_get_option( 'edd_continue_shopping_page' );
 		$cs_text           = edd_get_option( 'edd_continue_shopping_text' );
 		$cs_link_type      = edd_get_option( 'edd_continue_shopping_link_type' );
@@ -38,8 +38,12 @@ function eddcs_continue_shopping_link() {
 		if ( empty( $store_link ) ) {
 			return;
 		}
+
+		$link_text = ! empty( $cs_text ) ? $cs_text : __( 'Continue Shopping', 'edd-continue-shopping' );
 		?>
-		<a href="<?php echo esc_url( $store_link ); ?>" class="edd-continue-shopping-button <?php echo 'text' == $cs_link_type ? '' : 'edd-submit button ' . $color; ?>" style="<?php echo 'text' == $cs_link_type ? 'font-size: inherit; font-weight: 400; margin-right: 4px;' : 'text-decoration: none;'; ?>"><?php if ( false === $cs_text ) { _e( 'Continue Shopping', 'edd-continue-shopping' ); } elseif ( !empty( $cs_text ) ) { echo $cs_text; } ?></a>
+		<a href="<?php echo esc_url( $store_link ); ?>" class="edd-continue-shopping-button <?php echo 'text' == $cs_link_type ? '' : 'edd-submit button ' . $color; ?>" style="<?php echo 'text' == $cs_link_type ? 'font-size: inherit; font-weight: 400; margin-right: 4px;' : 'text-decoration: none;'; ?>">
+			<?php echo esc_html( $link_text ); ?>
+		</a>
 		<?php
 	}
 }


### PR DESCRIPTION
Closes #10

1. https://github.com/easydigitaldownloads/edd-continue-shopping/commit/46034a4b47b0d34165cd606541ed7576dd3f1f43 Rework store link logic to use `get_post_type_archive_link()` instead of manually building a URL.
2. https://github.com/easydigitaldownloads/edd-continue-shopping/commit/2763fc5905a57f0e04f0bd47f8e64a5e877007f5 Small formatting adjustments for readability.