### PR TITLE
Release/1.0.4

### DIFF
--- a/edd-continue-shopping.php
+++ b/edd-continue-shopping.php
@@ -4,13 +4,13 @@
  * Plugin URI: https://wordpress.org/plugins/easy-digital-downloads-continue-shopping/
  * Description: Adds a Continue Shopping link to the Easy Digital Downloads checkout cart.
  * Version: 1.0.3
- * Author: Sean Davis
- * Author URI: http://sdavismedia.com
+ * Author: Sandhills Development, LLC
+ * Author URI: https://sandhillsdev.com
  * Text Domain: edd-continue-shopping
  * Domain Path: /languages/
  *
  * @package         EDD\Continue Shopping
- * @author          Sean Davis
+ * @author          Sandhills Development, LLC
 */
 
 // Exit if accessed directly

--- a/edd-continue-shopping.php
+++ b/edd-continue-shopping.php
@@ -1,9 +1,9 @@
 <?php
-/*
+/**
  * Plugin Name: Easy Digital Downloads - Continue Shopping
  * Plugin URI: https://wordpress.org/plugins/easy-digital-downloads-continue-shopping/
  * Description: Adds a Continue Shopping link to the Easy Digital Downloads checkout cart.
- * Version: 1.0.3
+ * Version: 1.0.4
  * Author: Sandhills Development, LLC
  * Author URI: https://sandhillsdev.com
  * Text Domain: edd-continue-shopping
@@ -59,7 +59,7 @@ if( !class_exists( 'EDD_Continue_Shopping' ) ) {
 		private function setup_constants() {
 
 			// Plugin version
-			define( 'EDD_CONTINUE_SHOPPING_VER', '1.0.3' );
+			define( 'EDD_CONTINUE_SHOPPING_VER', '1.0.4' );
 
 			// Plugin path
 			define( 'EDD_CONTINUE_SHOPPING_DIR', plugin_dir_path( __FILE__ ) );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -7,7 +7,7 @@
  */
 
 // Exit if accessed directly
-if( !defined( 'ABSPATH' ) ) exit;
+if( ! defined( 'ABSPATH' ) ) exit;
 
 
 /**
@@ -16,15 +16,35 @@ if( !defined( 'ABSPATH' ) ) exit;
  * @since       1.0.0
  */
 function eddcs_continue_shopping_link() {
-	if ( class_exists( 'Easy_Digital_Downloads' ) && !edd_get_option( 'edd_continue_shopping' ) ) {
-		$store_link        = edd_get_option( 'edd_continue_shopping_page' );
-		$cs_text           = edd_get_option( 'edd_continue_shopping_text' );
-		$cs_link_type      = edd_get_option( 'edd_continue_shopping_link_type' );
-		$color             = edd_get_option( 'checkout_color', 'blue' );
-		$color             = ( $color == 'inherit' ) ? '' : $color;
-		?>
-		<a href="<?php echo $store_link ? get_permalink( $store_link ) : home_url( '/' . lcfirst( edd_get_label_plural() ) ); ?>" class="edd-continue-shopping-button <?php echo 'text' == $cs_link_type ? '' : 'edd-submit button ' . $color; ?>" style="<?php echo 'text' == $cs_link_type ? 'font-size: inherit; font-weight: 400; margin-right: 4px;' : 'text-decoration: none;'; ?>"><?php if ( false === $cs_text ) { _e( 'Continue Shopping', 'edd-continue-shopping' ); } elseif ( !empty( $cs_text ) ) { echo $cs_text; } ?></a>
-		<?php
+	if ( edd_get_option( 'edd_continue_shopping' ) ) {
+		return;
 	}
+
+	$store_page        = edd_get_option( 'edd_continue_shopping_page' );
+	$cs_text           = edd_get_option( 'edd_continue_shopping_text', __( 'Continue Shopping', 'edd-continue-shopping' ) );
+	$cs_link_type      = edd_get_option( 'edd_continue_shopping_link_type' );
+	$color             = edd_get_option( 'checkout_color', 'blue' );
+	$color             = ( $color == 'inherit' ) ? '' : $color;
+
+	$store_link = false;
+	if ( ! empty( $store_page ) ) {
+		$store_link = get_permalink( $store_page );
+	}
+	if ( empty( $store_link ) ) {
+		$store_link = get_post_type_archive_link( 'download' );
+	}
+
+	/*
+	 * This could still be empty if no page is selected and archives have been disabled
+	 * for the `download` post type.
+	 */
+	if ( empty( $store_link ) ) {
+		return;
+	}
+	?>
+	<a href="<?php echo esc_url( $store_link ); ?>" class="edd-continue-shopping-button <?php echo 'text' == $cs_link_type ? '' : 'edd-submit button ' . $color; ?>" style="<?php echo 'text' == $cs_link_type ? 'font-size: inherit; font-weight: 400; margin-right: 4px;' : 'text-decoration: none;'; ?>">
+		<?php echo esc_html( $cs_text ); ?>
+	</a>
+	<?php
 }
 add_action( 'edd_cart_footer_buttons', 'eddcs_continue_shopping_link' );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://easydigitaldownloads.com/donate/
 Tags: easy digital downloads, edd, shopping cart, checkout, ecommerce
 Requires at least: 3.9.2
 Tested up to: 5.7
-Stable tag: 1.0.3
+Stable tag: 1.0.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,10 @@ Follow EDD Continue Shopping’s development on [Github](https://github.com/easy
 2. Cart Output
 
 == Changelog ==
+
+= 1.0.4 =
+* Fix: "Continue Shopping" URL is incorrect if the "Download" label has been customized.
+* Tweak: Update plugin author name and URI.
 
 = 1.0.3 =
 * update EDD settings with dedicated subsection

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Easy Digital Downloads - Continue Shopping ===
-Contributors: sdavis2702
-Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=52HQDSEUA542S
+Contributors: easydigitaldownloads, sdavis2702
+Donate link: https://easydigitaldownloads.com/donate/
 Tags: easy digital downloads, edd, shopping cart, checkout, ecommerce
 Requires at least: 3.9.2
-Tested up to: 4.6
+Tested up to: 5.7
 Stable tag: 1.0.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -14,7 +14,7 @@ Adds a Continue Shopping link to the Easy Digital Downloads checkout cart.
 
 Built for use with the Easy Digital Downloads plugin, this extension displays a Continue Shopping link in the checkout cart and allows you to specify what page users will be sent to when they click the link.
 
-Follow EDD Continue Shopping’s development on [Github](https://github.com/sdavismedia/edd-continue-shopping).
+Follow EDD Continue Shopping’s development on [Github](https://github.com/easydigitaldownloads/edd-continue-shopping).
 
 == Installation ==
 


### PR DESCRIPTION
| Issue # | Description |
|---------|-------------|
| #10 | "Continue Shopping" URL is incorrect when download label name is customized |
| #8 | Update plugin to prevent appearing appearing as abandoned |
| #5 | Update plugin information and source |
